### PR TITLE
在订阅请求中可以指定start_date等

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,6 +92,10 @@ class CORSConfig(BaseModel):
     allow_methods: List[str] = Field(default_factory=lambda: ["*"])
     allow_headers: List[str] = Field(default_factory=lambda: ["*"])
 
+class UvicornConfig(BaseModel):
+    """uvicorn配置"""
+    timeout_keep_alive: int = 5
+
 
 class Settings(BaseModel):
     """完整配置类"""
@@ -102,6 +106,7 @@ class Settings(BaseModel):
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     redis: RedisConfig = Field(default_factory=RedisConfig)
     cors: CORSConfig = Field(default_factory=CORSConfig)
+    uvicorn: UvicornConfig = Field(default_factory=UvicornConfig)
     
     # gRPC 配置（使用属性访问以保持向后兼容）
     grpc_enabled: bool = True
@@ -191,7 +196,15 @@ def load_config(config_file: Optional[str] = None) -> Settings:
                 "allow_credentials": True,
                 "allow_methods": ["*"],
                 "allow_headers": ["*"]
-            })
+            }),
+            "uvicorn": {
+                "timeout_keep_alive": config_data.get("uvicorn", {}).get("timeout_keep_alive", 5)
+            },
+            "grpc_enabled": config_data.get("grpc", {}).get("enabled", True),
+            "grpc_host": config_data.get("grpc", {}).get("host", "0.0.0.0"),
+            "grpc_port": config_data.get("grpc", {}).get("port", 50051),
+            "grpc_max_workers": config_data.get("grpc", {}).get("max_workers", 10),
+            "grpc_max_message_length": config_data.get("grpc", {}).get("max_message_length", 50 * 1024 * 1024),
         }
         
         return Settings(**final_config)

--- a/app/models/data_models.py
+++ b/app/models/data_models.py
@@ -35,8 +35,8 @@ class MarketType(str, Enum):
 class DataRequest(BaseModel):
     """数据请求基础模型"""
     stock_codes: List[str] = Field(..., description="股票代码列表")
-    start_date: str = Field(..., description="开始日期 YYYYMMDD 或 YYYYMMDDHHMMSS")
-    end_date: str = Field(..., description="结束日期 YYYYMMDD 或 YYYYMMDDHHMMSS")
+    start_date: str = Field('', description="开始日期 YYYYMMDD 或 YYYYMMDDHHMMSS")
+    end_date: str = Field('', description="结束日期 YYYYMMDD 或 YYYYMMDDHHMMSS")
     period: PeriodType = Field(PeriodType.DAILY, description="数据周期")
     
     @field_validator('stock_codes')
@@ -47,6 +47,8 @@ class DataRequest(BaseModel):
     
     @field_validator('start_date', 'end_date')
     def validate_date_format(cls, v):
+        if v == '':
+            return v
         if (len(v) != 8 and len(v) != 14) or not v.isdigit():
             raise ValueError('日期格式必须为YYYYMMDD 或 YYYYMMDDHHMMSS')
         return v
@@ -517,6 +519,7 @@ class SubscriptionRequest(BaseModel):
     """订阅请求"""
     symbols: List[str] = Field(..., min_items=1, description="股票代码列表（不能为空）")    
     period: PeriodType = Field(PeriodType.TICK, description="数据周期")
+    start_date: str = Field('', description="开始日期 YYYYMMDD 或 YYYYMMDDHHMMSS")
     adjust_type: str = Field("none", description="复权类型: none, front, back, front_ratio, back_ratio")
     subscription_type: SubscriptionType = Field(
         SubscriptionType.QUOTE,
@@ -531,6 +534,14 @@ class SubscriptionRequest(BaseModel):
         v = [s.strip() for s in v if s and s.strip()]
         if not v:
             raise ValueError('股票代码列表不能为空')
+        return v
+    
+    @field_validator('start_date')
+    def validate_date_format(cls, v):
+        if v == '':
+            return v
+        if (len(v) != 8 and len(v) != 14) or not v.isdigit():
+            raise ValueError('日期格式必须为YYYYMMDD 或 YYYYMMDDHHMMSS')
         return v
     
     @field_validator('adjust_type')

--- a/app/routers/data.py
+++ b/app/routers/data.py
@@ -753,6 +753,7 @@ async def create_subscription(
             subscription_id = subscription_manager.subscribe_quote(
                 symbols=request.symbols,
                 period=request.period.value,
+                start_date=request.start_date,
                 adjust_type=request.adjust_type
             )
         
@@ -763,6 +764,8 @@ async def create_subscription(
             "created_at": datetime.now().isoformat(),
             "symbols": request.symbols if request.subscription_type == SubscriptionType.QUOTE else ["*"],
             "period": request.period.value,
+            "start_date": request.start_date,
+            "adjust_type": request.adjust_type,
             "subscription_type": request.subscription_type.value,
             "message": "订阅创建成功"
         }

--- a/app/services/data_service.py
+++ b/app/services/data_service.py
@@ -1129,6 +1129,7 @@ class DataService:
         try:
             if self._should_use_real_data():
                 try:
+                    logger.info(f"下载历史数据开始，stock: {stock_code} period: {period}")
                     # xtdata下载接口是同步的，会阻塞直到完成
                     xtdata.download_history_data(
                         stock_code=stock_code,
@@ -1172,6 +1173,7 @@ class DataService:
             if self._should_use_real_data():
                 try:
                     task_id = f"batch_download_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+                    logger.info(f"批量下载历史数据开始，任务ID: {task_id}, period: {period}, 股票数: {len(stock_list)}")
                     
                     # xtdata的批量下载接口
                     xtdata.download_history_data2(

--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@ def start_grpc():
 
 
 def print_banner(settings):
+    grpc_info = f"{settings.grpc_host}:{settings.grpc_port}" if settings.grpc_enabled else "未启用"
     """打印启动横幅"""
     print("\n" + "=" * 80)
     print("🚀 xtquant-proxy 服务启动中...")
@@ -28,7 +29,7 @@ def print_banner(settings):
     print(f"允许交易:     {'是' if settings.xtquant.trading.allow_real_trading else '否'}")
     print("-" * 80)
     print(f"REST API:     http://{settings.app.host}:{settings.app.port}")
-    print(f"gRPC 服务:    {settings.grpc_host}:{settings.grpc_port}")
+    print(f"gRPC 服务:    {grpc_info}")
     print(f"API 文档:     http://{settings.app.host}:{settings.app.port}/docs")
     print(f"日志级别:     {settings.logging.level}")
     print("=" * 80)
@@ -64,8 +65,9 @@ if __name__ == '__main__':
     print_banner(settings)
     
     # 在单独的线程中启动 gRPC 服务
-    grpc_thread = threading.Thread(target=start_grpc, daemon=True, name="gRPC-Server")
-    grpc_thread.start()
+    if settings.grpc_enabled:
+        grpc_thread = threading.Thread(target=start_grpc, daemon=True, name="gRPC-Server")
+        grpc_thread.start()
     
     # 主线程运行 FastAPI
     # 热加载配置：关闭热加载，或仅监控 .py 文件
@@ -83,5 +85,6 @@ if __name__ == '__main__':
         reload=reload_enabled,
         reload_includes=reload_includes,
         log_level=settings.logging.level.lower(),
-        access_log=True
+        access_log=True,
+        timeout_keep_alive=settings.uvicorn.timeout_keep_alive,
     )


### PR DESCRIPTION
修改点：
1. 在订阅请求中可以指定start_date

2. start_date/end_date可以不指定，默认值空串''

3. 增加了uvicorn.timeout_keep_alive, 默认值5秒，可在config.yml作如下配置
```
uvicorn:  
  timeout_keep_alive: 120  # 连接保持活动的超时时间（秒）
```
4. 生效了grpc相关配置，可在config.yml中disable grpc, 默认打开
```
grpc:
  enabled: false
```
5. 修改了上次提交的一个bug
```
-    xtdata.unsubscribe_quote_by_id(subid)
+    xtdata.unsubscribe_quote(subid)
```